### PR TITLE
pom.xml: Add Automatic-Module-Name to JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>${driver.maven-jar-plugin.version}</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>com.github.eduramiba.webcamcapture</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I tried to use the driver in an app using the Java Module System. Because the Java Module System assigns a module name based upon the JAR filename converting `-` to `.` *and* the JAR filename contains the substring `native` (a reserved word), it is not possible to use this JAR with the current generated module name.

Adding an `Automatic-Module-Name` header fixes the problem.